### PR TITLE
remove polyfill

### DIFF
--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Misc/Miscx_x_glossary.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Misc/Miscx_x_glossary.html
@@ -1549,7 +1549,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_1_RDM_with_NOMAD.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_1_RDM_with_NOMAD.html
@@ -1590,7 +1590,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_2_NOMAD_workflow.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_2_NOMAD_workflow.html
@@ -1525,7 +1525,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_3_NOMAD_datamodel.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_3_NOMAD_datamodel.html
@@ -1614,7 +1614,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_4_NOMAD_users.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_4_NOMAD_users.html
@@ -1587,7 +1587,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_5_getting_support.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module1/M1_5_getting_support.html
@@ -1626,7 +1626,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_NOMAD_GUI.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_NOMAD_GUI.html
@@ -1619,7 +1619,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_create_account.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_create_account.html
@@ -1510,7 +1510,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_customized_search_dashboard.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_customized_search_dashboard.html
@@ -1668,7 +1668,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_explore_tab.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_explore_tab.html
@@ -1695,7 +1695,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_explore_use_cases.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_explore_use_cases.html
@@ -1708,7 +1708,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_inspecting_entry_pages.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_inspecting_entry_pages.html
@@ -1614,7 +1614,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_upload_data.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module2/M2_x_upload_data.html
@@ -1631,7 +1631,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_1_0_ELN_overview_combined_concise.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_1_0_ELN_overview_combined_concise.html
@@ -1642,7 +1642,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_0_getting_started_combined_concise.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_0_getting_started_combined_concise.html
@@ -1587,7 +1587,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_1_creating_entries_built-in_schema.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_1_creating_entries_built-in_schema.html
@@ -1631,7 +1631,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_2_creating_entities.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_2_creating_entities.html
@@ -1539,7 +1539,6 @@ The polymer powder, solvent, and substrate are considered to be the substances u
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_3_substance_entities.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_3_substance_entities.html
@@ -1648,7 +1648,6 @@ Add as many elements as needed to represent your substance. This section is usef
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_4_sample_entites.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_4_sample_entites.html
@@ -1643,7 +1643,6 @@ Note that only items such as Samples or Substances can be selected in the System
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_5_instrument_entities.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_5_instrument_entities.html
@@ -1556,7 +1556,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_6_creating_activities.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_6_creating_activities.html
@@ -1517,7 +1517,6 @@ For this, we will use the built-in ELN schema <em>Material Processing ELN</em>. 
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_7_materials_processing_activitiy.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_7_materials_processing_activitiy.html
@@ -1606,7 +1606,6 @@ The changes will be reflected in the Workflow section and the Reference section 
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_8_measurement_activity.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_2_8_measurement_activity.html
@@ -1527,7 +1527,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_3_0_managing_experiments.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_3_0_managing_experiments.html
@@ -1636,7 +1636,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_3_1_integrating_your_experiment.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_3_1_integrating_your_experiment.html
@@ -1608,7 +1608,6 @@ This can be entered manually.</p>
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_3_2_organizing_your_upload.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_3_2_organizing_your_upload.html
@@ -1649,7 +1649,6 @@ You can drag-and-drop the entry files into the relevant folder. A prompt will ap
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_4_0_sharing_your_eln.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/5_ELN_using_built-in_schema/M3_4_0_sharing_your_eln.html
@@ -1613,7 +1613,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/6_ELN_using_custom_schema/M3_4_1_ground_guidelines.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/6_ELN_using_custom_schema/M3_4_1_ground_guidelines.html
@@ -1601,7 +1601,6 @@ This is useful because NOMAD offers several built-in objects called base section
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/6_ELN_using_custom_schema/M3_4_2_basic_eln.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/6_ELN_using_custom_schema/M3_4_2_basic_eln.html
@@ -1758,7 +1758,6 @@ Let's create a few entries with your first ELN. </p>
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/6_ELN_using_custom_schema/M3_4_3_measurement_data.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module3/6_ELN_using_custom_schema/M3_4_3_measurement_data.html
@@ -2036,7 +2036,6 @@ Finally, plot's title is set using the <code>layout</code> key.</p>
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_0_overview.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_0_overview.html
@@ -1515,7 +1515,6 @@
     
       <script src="../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_0_getting_started.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_0_getting_started.html
@@ -1571,7 +1571,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_1_preparing_local.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_1_preparing_local.html
@@ -1664,7 +1664,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_2_preparing_north.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_2_preparing_north.html
@@ -1590,7 +1590,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_3_api_basics.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_1_getting_started/M4_1_3_api_basics.html
@@ -1706,7 +1706,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_1_example_api_explained.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_1_example_api_explained.html
@@ -1795,7 +1795,6 @@ The response you receive should look similar to what you have received when you 
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_2_leveraging_pagination.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_2_leveraging_pagination.html
@@ -1707,7 +1707,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_3_api_helpers/M4_2_3_0_nomad_api_helpers.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_3_api_helpers/M4_2_3_0_nomad_api_helpers.html
@@ -1644,7 +1644,6 @@
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_3_api_helpers/M4_2_3_1_helper_explore.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_3_api_helpers/M4_2_3_1_helper_explore.html
@@ -1702,7 +1702,6 @@ You can download this JSON object and use it programmatically to extract the <co
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_3_api_helpers/M4_2_3_2_helper_entry_page.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_2_retrieve_data/M4_2_3_api_helpers/M4_2_3_2_helper_entry_page.html
@@ -1716,7 +1716,6 @@ Indentation just helps to easily identify the structure and hierarchy of the JSO
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_3_upload_data/M4_3_1_authentication.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_3_upload_data/M4_3_1_authentication.html
@@ -1680,7 +1680,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_3_upload_data/M4_3_2_upload.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_3_upload_data/M4_3_2_upload.html
@@ -1622,7 +1622,6 @@ You can now check the response, e.g., print it to see if the file has been uploa
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_0_overview.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_0_overview.html
@@ -1481,7 +1481,6 @@
     
       <script src="../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_0_perovskites_crabnet_overview.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_0_perovskites_crabnet_overview.html
@@ -1597,7 +1597,6 @@
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_1_perovskites_crabnet_retrieve_data_api.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_1_perovskites_crabnet_retrieve_data_api.html
@@ -1741,7 +1741,6 @@
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_2_perovskites_crabnet_load_and_clean_data.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_2_perovskites_crabnet_load_and_clean_data.html
@@ -1701,7 +1701,6 @@ in case of problems, try it from its developer repo</p>
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_3_perovskites_crabnet_ml.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/Module4/M4_x_examples/M4_x_1_perovskites_crabnet_ml/M4_x_3_perovskites_crabnet_ml.html
@@ -1749,7 +1749,6 @@ Then define a function and run it for predicting the bandgap from individual for
     
       <script src="../../../assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/index.html
+++ b/data/fetched/nomad-onboarding-workshop/html/nomad-onboarding-workshop/index.html
@@ -1495,7 +1495,6 @@
     
       <script src="assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       

--- a/data/fetched/nomad-onboarding-workshop/index.html
+++ b/data/fetched/nomad-onboarding-workshop/index.html
@@ -1495,7 +1495,6 @@
     
       <script src="assets/javascripts/bundle.da79ceb7.min.js"></script>
       
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
       
         <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       


### PR DESCRIPTION
see https://github.com/FAIRmat-NFDI/nomad-docs/pull/228


I guess these docs are collected for all our repos, not sure if we should rerun the collecting script?


I guess these HTMLs are not really going to be deployed but still better to get rid of them as they would pollute the org-level search for polyfill

